### PR TITLE
fix(utxo-lib): honor caller hashType for SmartTransaction signatures (atomic-swap offers)

### DIFF
--- a/dist/src/transaction_builder.js
+++ b/dist/src/transaction_builder.js
@@ -749,7 +749,9 @@ TransactionBuilder.prototype.sign = function (vin, keyPair, redeemScript, hashTy
             signature = ECSignature.fromRSBuffer(signature);
         debug('Produced signature (r: %s, s: %s)', signature.r, signature.s);
         if (input.signType === scriptTypes.SMART_TRANSACTION) {
-            input.signatures[i] = new SmartTransactionSignatures(1, 1, [
+            // Blob must declare the same hashtype used for the digest above,
+            // or verification fails (e.g. SIGHASH_SINGLE|ANYONECANPAY offers).
+            input.signatures[i] = new SmartTransactionSignatures(1, hashType, [
                 new SmartTransactionSignature(1, 1, pubKey, signature.toCompact().slice(1))
             ]).toChunk();
         }
@@ -768,6 +770,17 @@ TransactionBuilder.prototype.__canModifyInputs = function () {
         // any signatures?
         if (input.signatures === undefined)
             return true;
+        if (input.signType === scriptTypes.SMART_TRANSACTION) {
+            var smartTxSigs = SmartTransactionSignatures.fromChunk(bscript.decompile(input.signatures)[0]);
+            if (smartTxSigs.error != null ||
+                smartTxSigs.signatures.length === 0 ||
+                smartTxSigs.signatures.every(function (sig) { return sig.oneSignature.length === 0; })) {
+                return true;
+            }
+            // Smart transaction signatures declare their hash type in the
+            // serialized blob header, not in the trailing byte of a DER signature.
+            return (smartTxSigs.sigHashType & Transaction.SIGHASH_ANYONECANPAY) !== 0;
+        }
         return input.signatures.every(function (signature) {
             if (!signature)
                 return true;
@@ -781,7 +794,7 @@ TransactionBuilder.prototype.__canModifyInputs = function () {
 TransactionBuilder.prototype.__canModifyOutputs = function () {
     var nInputs = this.tx.ins.length;
     var nOutputs = this.tx.outs.length;
-    return this.inputs.every(function (input) {
+    return this.inputs.every(function (input, vin) {
         if (input.signatures === undefined)
             return true;
         if (input.signType === scriptTypes.SMART_TRANSACTION) {
@@ -791,6 +804,15 @@ TransactionBuilder.prototype.__canModifyOutputs = function () {
                 smartTxSigs.signatures.every(function (sig) { return sig.oneSignature.length === 0; })) {
                 return true;
             }
+            // Smart transaction signatures declare their hash type in the blob
+            // header. SIGHASH_SINGLE binds this input to the output at the same
+            // index, so appending outputs is safe once that output exists.
+            var smartHashTypeMod = smartTxSigs.sigHashType & 0x1f;
+            if (smartHashTypeMod === Transaction.SIGHASH_NONE)
+                return true;
+            if (smartHashTypeMod === Transaction.SIGHASH_SINGLE)
+                return vin < nOutputs;
+            return false;
         }
         return input.signatures.every(function (signature) {
             if (!signature)

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -860,7 +860,11 @@ TransactionBuilder.prototype.sign = function (vin, keyPair, redeemScript, hashTy
     debug('Produced signature (r: %s, s: %s)', signature.r, signature.s)
 
     if (input.signType === scriptTypes.SMART_TRANSACTION) {
-      input.signatures[i] = new SmartTransactionSignatures(1, 1, [
+      // The signature digest above is computed with the caller-requested
+      // hashType; the serialized blob must declare the SAME hashtype or
+      // verification recomputes the digest differently and fails (e.g.
+      // SIGHASH_SINGLE|ANYONECANPAY atomic-swap offers).
+      input.signatures[i] = new SmartTransactionSignatures(1, hashType, [
         new SmartTransactionSignature(
           1,
           1,
@@ -885,6 +889,22 @@ TransactionBuilder.prototype.__canModifyInputs = function () {
     // any signatures?
     if (input.signatures === undefined) return true
 
+    if (input.signType === scriptTypes.SMART_TRANSACTION) {
+      const smartTxSigs = SmartTransactionSignatures.fromChunk(bscript.decompile(input.signatures)[0])
+
+      if (
+        smartTxSigs.error != null ||
+        smartTxSigs.signatures.length === 0 ||
+        smartTxSigs.signatures.every((sig) => sig.oneSignature.length === 0)
+      ) {
+        return true
+      }
+
+      // Smart transaction signatures declare their hash type in the
+      // serialized blob header, not in the trailing byte of a DER signature.
+      return (smartTxSigs.sigHashType & Transaction.SIGHASH_ANYONECANPAY) !== 0
+    }
+
     return input.signatures.every(function (signature) {
       if (!signature) return true
       var hashType = signatureHashType(signature)
@@ -900,7 +920,7 @@ TransactionBuilder.prototype.__canModifyOutputs = function () {
   var nInputs = this.tx.ins.length
   var nOutputs = this.tx.outs.length
 
-  return this.inputs.every(function (input) {
+  return this.inputs.every(function (input, vin) {
     if (input.signatures === undefined) return true
 
     if (input.signType === scriptTypes.SMART_TRANSACTION) {
@@ -913,6 +933,14 @@ TransactionBuilder.prototype.__canModifyOutputs = function () {
       ) {
         return true
       }
+
+      // Smart transaction signatures declare their hash type in the blob
+      // header. SIGHASH_SINGLE binds this input to the output at the same
+      // index, so appending outputs is safe once that output exists.
+      var smartHashTypeMod = smartTxSigs.sigHashType & 0x1f
+      if (smartHashTypeMod === Transaction.SIGHASH_NONE) return true
+      if (smartHashTypeMod === Transaction.SIGHASH_SINGLE) return vin < nOutputs
+      return false
     }
 
     return input.signatures.every(function (signature) {


### PR DESCRIPTION
## Summary
`TransactionBuilder` treated SmartTransaction (VerusID / CryptoCondition) signatures as if they were always `SIGHASH_ALL`, which made atomic-swap **offers** — signed `SIGHASH_SINGLE | ANYONECANPAY` so a taker can complete them — impossible to build or verify. This fixes both the signing and the mutability guards.

### 1. `sign()` — declare the real hashtype in the blob
The `SmartTransactionSignatures` blob hardcoded `sigHashType = 1` while the digest was computed with the caller-supplied `hashType`. Any non-ALL smart signature therefore verified against the wrong digest and the completed transaction was rejected (`mandatory-script-verify-flag-failed`, false/empty top stack).

### 2. `__canModifyInputs` / `__canModifyOutputs` — read the blob header, not a DER byte
Both guards derived the hashtype from the trailing byte of a DER signature, which is meaningless for a `SmartTransactionSignatures` blob. As a result, adding a takers inputs/outputs to a maker-signed offer threw `No, this would invalidate signatures`. They now parse the blob header via `SmartTransactionSignatures.fromChunk`:
- **inputs:** `ANYONECANPAY` permits appending more inputs.
- **outputs:** `SIGHASH_SINGLE` permits appending outputs once the paired (same-index) output exists (`vin < nOutputs`); `SIGHASH_NONE` always permits.

Applied to both `src/` and `dist/src/`.

## Why it matters
This is what lets a wallet act as an atomic-swap **taker** entirely client-side: keep the makers `SINGLE|ANYONECANPAY` identity input untouched, add the buyers funding inputs + the transferred identity output + change, sign only the buyer inputs, and broadcast.

## Testing
Proven live on VRSCTEST via the Verus Mobile marketplace flows: a maker offer signed `SINGLE|ANYONECANPAY` is completed by a taker on a second device; the swap settles on-chain and the identity transfers to the buyer with **revocation/recovery authorities preserved**. Two independent on-device swaps across two phones passed first-try.

Downstream (Verus-Mobile) currently carries this as a `patch-package` patch; merging here lets that patch be dropped.
